### PR TITLE
Add support for TMPDIR variable (fixes #1)

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -5,6 +5,7 @@
 */
 
 #include "logging.h"
+#include "string.h"
 
 int unsafe_val=0;
 FILE *unsafe_fptr;
@@ -83,8 +84,13 @@ void armpl_logging_leave(armpl_logging_struct *logger)
 
   if (firsttime==1)
   {
-  	char fname[32];
-  	sprintf(fname, "/tmp/armpllog_%.5d.apl", armpl_get_value_int());
+	const char* tmpdir = getenv("TMPDIR");
+	if (!tmpdir)
+	{
+		tmpdir = "/tmp";
+	}
+	char *fname = calloc(strlen(tmpdir)+strlen("/armpllog_NNNNN.apl")+1,sizeof(char));
+        sprintf(fname, "%s/armpllog_%.5d.apl", tmpdir, armpl_get_value_int());
 
   	fptr = armpl_open_logging_file(fname);
   }

--- a/src/summary.c
+++ b/src/summary.c
@@ -16,11 +16,16 @@ void armpl_summary_exit()
   armpl_lnkdlst_t *thisEntry = listHead;
   armpl_lnkdlst_t *nextEntry = listHead;
   FILE *fptr;
-  char fname[64];
   static int firsttime=0;
   
   /* Generate a "unique" filename for the output */
-  sprintf(fname, "/tmp/armplsummary_%.5d.apl", armpl_get_value_int());
+  const char* tmpdir = getenv("TMPDIR");
+  if (!tmpdir)
+  {
+      tmpdir = "/tmp";
+  }
+  char *fname = calloc(strlen(tmpdir)+strlen("/armplsummary_NNNNN.apl")+1,sizeof(char));
+  sprintf(fname, "%s/armplsummary_%.5d.apl", tmpdir, armpl_get_value_int());
   fptr = fopen(fname, "w");
 
   while (NULL != listEntry)

--- a/tools/process-blas.sh
+++ b/tools/process-blas.sh
@@ -16,9 +16,9 @@ BLAS1="rotg_ rotmg_ rot_ rotm_ swap_ scal_ copy_ axpy_ dot_ dotu_ dotc_ nrm2_ as
 BLAS2="gemv_ gbmv_ hemv_ hbmv_ hpmv_ symv_ sbmv_ spmv_ trmv_ tbmv_ tpmv_ trsv_ tbsv_ tpsv_ ger_ geru_ gerc_ her_ hpr_ her2_ hpr2_ syr_ spr_ syr2_ spr2_"
 BLAS3="gemm_ symm_ hemm_ syrk_ herk_ syr2k_ her2k_ trmm_ trsm_"
 
-
-TMPFILE=/tmp/.inp-$USER
-OUTFILE=/tmp/armpl.blas
+: "${TMPDIR:=/tmp}"
+TMPFILE=${TMPDIR}/.inp-$USER
+OUTFILE=${TMPDIR}/armpl.blas
 
 cat $* > $TMPFILE
 rm -f $OUTFILE

--- a/tools/process-dgemm.c
+++ b/tools/process-dgemm.c
@@ -193,8 +193,14 @@ int main(int argc, char** argv)
 	}
 
 	/* Open file for output */
-	char *outFname = calloc(strlen("/tmp/armpl.")+strlen(funcNames[funcNameID])+1,sizeof(char));
-	strcat(outFname,"/tmp/armpl.");
+	const char* tmpdir = getenv("TMPDIR");
+	if (!tmpdir)
+	{
+		tmpdir = "/tmp";
+	}
+	char *outFname = calloc(strlen(tmpdir)+strlen("/armpl.")+strlen(funcNames[funcNameID])+1,sizeof(char));
+	strcat(outFname,tmpdir);
+	strcat(outFname,"/armpl.");
 	strcat(outFname,funcNames[funcNameID]);
 	fptr = fopen(outFname, "w");
 	if (fptr == NULL) {

--- a/tools/process-dgemm.sh
+++ b/tools/process-dgemm.sh
@@ -21,7 +21,8 @@ then
 	echo "  $ gcc -o Process-dgemm process-dgemm.c"
 fi
 
-TMPFILE=/tmp/.inp-$USER
+: "${TMPDIR:=/tmp}"
+TMPFILE=${TMPDIR}/.inp-$USER
 
 rm -f $TMPFILE
 for file in $*

--- a/tools/process_summary.py
+++ b/tools/process_summary.py
@@ -598,7 +598,8 @@ def process_components():
   #####
   
   if (len(blasNames[0])+len(blasNames[1])+len(blasNames[2])>0) :
-     fname = '/tmp/armpl.blas'
+     tmpdir = os.getenv('TMPDIR','/tmp')
+     fname = tmpdir + '/armpl.blas'
      outputfile = open(fname, 'w')
 
      types="sdcz"


### PR DESCRIPTION
Currently the output files are hardcoded to be under `/tmp`. This PR adds support for the user specifying an alternative prefix via the `TMPDIR` environment variable.

An internal code review suggeseted allocating the space for the filename on the heap rather than the stack. (Now that the prefix can be user supplied it could be up to `PATH_MAX` == 4096 bytes)

There is a possibility that the process ID could be longer than five characters. On the system I have access to this isn't the case

```ShellSession
$ cat /proc/sys/kernel/pid_max
57344
```