### PR TITLE
Fix crashes caused by overflowing the fname array

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -84,7 +84,7 @@ void armpl_logging_leave(armpl_logging_struct *logger)
 
   if (firsttime==1)
   {
-  	char fname[32];
+  	char fname[128];
   	/* Generate a "unique" filename for the output */
   	USERENV = getenv("ARMPL_LOGING_FILEROOT");
   	if (USERENV!=NULL && strlen(USERENV)>1) 

--- a/src/summary.c
+++ b/src/summary.c
@@ -32,7 +32,7 @@ void armpl_summary_exit()
   armpl_lnkdlst_t *thisEntry = listHead;
   armpl_lnkdlst_t *nextEntry = listHead;
   FILE *fptr;
-  char fname[256];
+  char fname[512];
   static int firsttime = 0;
   static int increment = 0;
   struct timespec armpl_progstop;


### PR DESCRIPTION
These two commits fix two different crashes that can occur due to overflowing the fname array.